### PR TITLE
Adding Laravel 5.5 Auto Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,15 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Ably\\Laravel\\AblyServiceProvider"
+            ],
+            "aliases": {
+                "Ably": "Ably\\Laravel\\Facades\Ably"
+            }
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
                 "Ably\\Laravel\\AblyServiceProvider"
             ],
             "aliases": {
-                "Ably": "Ably\\Laravel\\Facades\Ably"
+                "Ably": "Ably\\Laravel\\Facades\\Ably"
             }
         }
     }


### PR DESCRIPTION
fixes #3 

Note, documentation will need to be updated to let people know they no longer have to register this in the app.php config file if they are running Laravel 5.5+