### PR TITLE
Allow dependendy injection from the service container

### DIFF
--- a/src/AblyServiceProvider.php
+++ b/src/AblyServiceProvider.php
@@ -37,6 +37,8 @@ class AblyServiceProvider extends ServiceProvider
             
             return new AblyRest(config('ably'));
         });
+        
+        $this->app->alias('ably', AblyRest::class);
     }
 
     /**
@@ -47,7 +49,8 @@ class AblyServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'ably'
+            'ably',
+            AblyRest::class,
         ];
     }
 }


### PR DESCRIPTION
Makes it resolvable via it's `::class` and when injected into e.g. controller methods or service providers.