### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,8 +7,12 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
+    permissions:
+      contents: read
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,13 +21,13 @@ jobs:
         php-version: [7.2, 7.3, 7.4, 8.0]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: 'recursive'
           persist-credentials: false
 
       - name: Set up PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php-version }}
 


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflow in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on `actions/checkout` so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
- Scope the workflow's permissions explicitly: top-level `permissions: {}`, with the `check` job granted only the `contents: read` scope it actually needs.
- Pin third-party actions (`actions/checkout`, `shivammathur/setup-php`) to commit SHAs with the tag preserved as a comment, so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflow runs the same checks against the same inputs.